### PR TITLE
Issue 23

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -2,7 +2,7 @@ call yarn pack || goto :error
 call yarn licenses generate-disclaimer > ThirdPartyLicenses.txt || goto :error
 
 call npm config set prefix %BUILD_PREFIX% || goto :error
-call npm install --global %PKG_NAME%-v%PKG_VERSION%.tgz || goto :error
+call npm install --userconfig nonexistentrc --global %PKG_NAME%-v%PKG_VERSION%.tgz || goto :error
 
 :error
 echo Failed with error #%errorlevel%.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 86c6af269a5d6e15924d8d718ceb534542549ab94d66deade740d1465fa89d79
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
Close #23 

This should fix the Windows build.

- In #17, I stopped testing builds locally after https://github.com/conda-forge/prettier-feedstock/pull/17/commits/ac105d2ebbde7d23cf0afbc8c4da13c1e2adb6d9 and relied on CI instead. I'm surprised that CI succeeded, as the commits afterward fail locally.
- I'm not sure why the `--userconfig` needs to be practically 'unset' (point to a non-existing file). Something in the default user config seems to break the build. Maybe one day I will investigate.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
